### PR TITLE
bin/console: require existing files

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "rake/contrib"
+require "rake/contrib/compositepublisher"
+require "rake/contrib/ftptools"
+require "rake/contrib/sshpublisher"
 
 require "irb"
 IRB.start


### PR DESCRIPTION
This PR fixes the issue that `bin/console` errors with a load error on starting it.

It's referred to in the Bundler-created README text.