### PR TITLE
gemspec: lib/, README, LICENSE

### DIFF
--- a/rake-contrib.gemspec
+++ b/rake-contrib.gemspec
@@ -9,9 +9,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/ruby/rake-contrib"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files         = Dir["lib/**/*.rb", "README.md", "LICENSE.txt"]
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rake"


### PR DESCRIPTION
This PR changes the gemspec to include fewer files.

This gem exposes no executables, so we can omit directives about that.